### PR TITLE
Fixing cooldown issue in code scanning

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,8 @@ updates:
     open-pull-requests-limit: 10
     commit-message:
       prefix: "[gomod] "
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -19,6 +21,8 @@ updates:
     open-pull-requests-limit: 10
     commit-message:
       prefix: "[gha] "
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "docker"
     directory: "/"
@@ -27,3 +31,5 @@ updates:
     open-pull-requests-limit: 10
     commit-message:
       prefix: "[docker] "
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
This pull request updates the Dependabot configuration to introduce a cooldown period for dependency updates. This change helps prevent Dependabot from opening pull requests too frequently for the same dependencies across Go modules, GitHub Actions, and Docker, making dependency management less noisy and more manageable.

Dependabot configuration improvements:

* Added a `cooldown` setting with `default-days: 7` to the Go modules ecosystem to limit how often Dependabot can open PRs for the same dependency.
* Added a `cooldown` setting with `default-days: 7` to the GitHub Actions ecosystem for the same purpose.
* Added a `cooldown` setting with `default-days: 7` to the Docker ecosystem to control PR frequency.