### PR TITLE
Enable post-merge security scans for tag creation

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -9,6 +9,8 @@ on:
     branches:
       - main
       - release-*
+    tags:
+      - '*'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
This pull request makes a minor update to the GitHub Actions workflow configuration. The change ensures that the `post-merge.yml` workflow will also be triggered when any tag is pushed, in addition to the existing triggers for the `main` and `release-*` branches.

* Added a trigger for all tag pushes to the `on:` section of `.github/workflows/post-merge.yml`