### PR TITLE
Remove trigger on tag from post-merge workflows

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -9,8 +9,6 @@ on:
     branches:
       - main
       - release-*
-    tags:
-      - '*'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
This pull request makes a small update to the workflow trigger configuration in `.github/workflows/post-merge.yml`. The change removes the workflow's ability to be triggered by tags, so it will now only run on pushes to the `main` and `release-*` branches, or when manually dispatched.